### PR TITLE
Explanation that liquibase runs on server startup

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -36,6 +36,9 @@ SELECT datname FROM pg_database WHERE datistemplate = false;
 
 This will generate the initial database, and from this point any DB related changes will be through [Liquibase](Liquibase.md).
 
+Liquibase runs automatically during server startup and update the DB (if 
+needed).
+
 ### Step 2, compile the application
 
 From the fp-psp-server directory, run:


### PR DESCRIPTION
Add an explanation to the Run.md that should clarify the process of database
update. It was a bit confusing that liquibase runs automatically during server
startup and it wasn't clear for a new user.