### PR TITLE
Changes the 'task' concept to 'intervention'

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-evolution.xml
+++ b/src/main/resources/db/changelog/db.changelog-evolution.xml
@@ -44,4 +44,11 @@
 	    <sqlFile path="sql/2017-09-22T12:00.sql" relativeToChangelogFile="true"/>
     </changeSet>
 
+    <!--
+    It changes the "track" concept to "intervention" in the table "task" from the schema "survey"
+    -->
+    <changeSet id="2017-09-25T11:00" author="nvaldez">
+        <sqlFile path="sql/2017-09-25T11:00.sql" relativeToChangelogFile="true"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/2017-09-25T11:00.sql
+++ b/src/main/resources/db/changelog/sql/2017-09-25T11:00.sql
@@ -1,0 +1,5 @@
+ALTER TABLE survey.task
+    RENAME TO intervention;
+
+ALTER TABLE survey.intervention
+    RENAME task_id TO intervention_id;


### PR DESCRIPTION
A Liquibase script that changes both the name and columns with the
concept 'task' to 'intervention'. The table corresponds to the schema
'survey'.