### PR TITLE
Replaces task_tracking with intervention_tracking

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-evolution.xml
+++ b/src/main/resources/db/changelog/db.changelog-evolution.xml
@@ -58,4 +58,11 @@
         <sqlFile path="sql/2017-09-26T12:00.sql" relativeToChangelogFile="true"/>
     </changeSet>
 
+    <!--
+    Change the "task_tracking" concept to "intervention_tracking" in the 'task_tracking' table from the schema 'survey'
+    -->
+    <changeSet id="2017-09-25T11:30" author="nvaldez">
+        <sqlFile path="sql/2017-09-25T11:30.sql" relativeToChangelogFile="true"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/2017-09-25T11:30.sql
+++ b/src/main/resources/db/changelog/sql/2017-09-25T11:30.sql
@@ -1,0 +1,8 @@
+ALTER TABLE survey.task_tracking
+    RENAME TO intervention_tracking;
+
+ALTER TABLE survey.intervention_tracking
+    RENAME task_tracking_id TO intervention_tracking_id;
+
+ALTER TABLE survey.intervention_tracking
+    RENAME task_id TO intervention_id;


### PR DESCRIPTION
A Liquibase script that changes both the name and columns with the
concept 'task_tracking' to 'intervention_tracking'. The table
corresponds to the schema 'survey'.