### PR TITLE
Add filtering by family to the snapshot endpoint

### DIFF
--- a/src/main/java/py/org/fundacionparaguaya/pspserver/common/entities/BaseEntity.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/common/entities/BaseEntity.java
@@ -2,9 +2,11 @@ package py.org.fundacionparaguaya.pspserver.common.entities;
 
 import java.io.Serializable;
 
+import javax.persistence.Inheritance;
 import javax.persistence.MappedSuperclass;
 
 @MappedSuperclass
+@Inheritance
 public abstract class BaseEntity implements Serializable {
 
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/repositories/SnapshotEconomicRepository.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/repositories/SnapshotEconomicRepository.java
@@ -5,12 +5,15 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
 import py.org.fundacionparaguaya.pspserver.surveys.entities.SnapshotEconomicEntity;
 
 /**
  * Created by rodrigovillalba on 10/19/17.
  */
-public interface SnapshotEconomicRepository extends JpaRepository<SnapshotEconomicEntity, Long> {
+public interface SnapshotEconomicRepository extends JpaRepository<SnapshotEconomicEntity, Long>, 
+        JpaSpecificationExecutor<SnapshotEconomicEntity> {
     Collection<SnapshotEconomicEntity> findBySurveyDefinitionId(Long surveyId);
     Optional<SnapshotEconomicEntity> findFirstByFamilyFamilyIdOrderByCreatedAtDesc(Long familyId);
     List<SnapshotEconomicEntity> findByFamilyFamilyId(Long familyId);

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/services/impl/SnapshotServiceImpl.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/services/impl/SnapshotServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,6 +41,7 @@ import py.org.fundacionparaguaya.pspserver.surveys.repositories.SurveyRepository
 import py.org.fundacionparaguaya.pspserver.surveys.services.SnapshotIndicatorPriorityService;
 import py.org.fundacionparaguaya.pspserver.surveys.services.SnapshotService;
 import py.org.fundacionparaguaya.pspserver.surveys.services.SurveyService;
+import py.org.fundacionparaguaya.pspserver.surveys.specifications.SnapshotEconomicSpecification;
 import py.org.fundacionparaguaya.pspserver.surveys.validation.ValidationResults;
 
 /**
@@ -138,8 +140,12 @@ public class SnapshotServiceImpl implements SnapshotService {
     }
 
     @Override
-    public List<Snapshot> find(Long surveyId, Long familiyId) {
-        return economicRepository.findBySurveyDefinitionId(surveyId).stream().map(economicMapper::entityToDto)
+    public List<Snapshot> find(Long surveyId, Long familyId) {
+        return economicRepository.findAll(Specifications
+                .where(SnapshotEconomicSpecification.forSurvey(surveyId))
+                .and(SnapshotEconomicSpecification.forFamily(familyId)))
+                .stream()
+                .map(economicMapper::entityToDto)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/specifications/SnapshotEconomicSpecification.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/surveys/specifications/SnapshotEconomicSpecification.java
@@ -1,0 +1,29 @@
+package py.org.fundacionparaguaya.pspserver.surveys.specifications;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import py.org.fundacionparaguaya.pspserver.surveys.entities.SnapshotEconomicEntity;
+
+/**
+ * Specifications used to find a snapshot economic entity from the repository.
+ */
+public class SnapshotEconomicSpecification {
+
+    public static Specification<SnapshotEconomicEntity> forFamily(Long familyId) {
+        return (root, query, cb) -> {
+            if (familyId == null) {
+                return null;
+            }
+            return cb.equal(root.join("family").get("familyId"), familyId);
+        };
+    }
+
+    public static Specification<SnapshotEconomicEntity> forSurvey(Long surveyId) {
+        return (root, query, cb) -> {
+            if (surveyId == null) {
+                return null;
+            }
+            return cb.equal(root.join("surveyDefinition").get("id"), surveyId);
+        };
+    }
+}


### PR DESCRIPTION
This uses Java's JPA syntax to finish the implementation for the `/snapshots` endpoint. This doesn't change the endpoint at all (there was already a `family_id` GET argument for the endpoint, it just wasn't being used).

I've ensured that this does properly handle the scenario where the `family_id` is not specified in the request (in which case it will select all snapshots for the specified `survey_id`), the scenario where `family_id` is empty, the scenario where `family_id` is invalid (e.g. -1), and the scenario where there are no families with the given `family_id`.