### PR TITLE
FPPSP-263 - Change family assigned survey user

### DIFF
--- a/src/main/java/py/org/fundacionparaguaya/pspserver/families/repositories/FamilyRepository.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/families/repositories/FamilyRepository.java
@@ -10,15 +10,15 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import py.org.fundacionparaguaya.pspserver.families.entities.FamilyEntity;
 
-public interface FamilyRepository extends JpaRepository<FamilyEntity, Long>,
-                JpaSpecificationExecutor<FamilyEntity> {
+public interface FamilyRepository extends JpaRepository<FamilyEntity, Long>, JpaSpecificationExecutor<FamilyEntity> {
 
     Optional<FamilyEntity> findByCode(String code);
 
     Page<FamilyEntity> findAll(Pageable page);
 
     List<FamilyEntity> findByNameContainingIgnoreCase(String freeText);
-    
+
     List<FamilyEntity> findByOrganizationId(Long organizationId);
 
+    List<FamilyEntity> findDistinctByUserId(Long userId);
 }

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/FamilyService.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/FamilyService.java
@@ -45,8 +45,7 @@ public interface FamilyService {
     FamilyEntity getOrCreateFamilyFromSnapshot(UserDetailsDTO details,
             NewSnapshot snapshot, PersonEntity personEntity);
 
-    List<FamilyDTO> listDistinctFamiliesSnapshotByUser(UserDetailsDTO details,
-            String name);
+    List<FamilyDTO> listDistinctFamiliesByUser(UserDetailsDTO details, String name);
 
     FamilyDTO updateFamily(Long familyId);
 

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/impl/FamilyServiceImpl.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/impl/FamilyServiceImpl.java
@@ -25,6 +25,7 @@ import py.org.fundacionparaguaya.pspserver.network.entities.OrganizationEntity;
 import py.org.fundacionparaguaya.pspserver.network.mapper.ApplicationMapper;
 import py.org.fundacionparaguaya.pspserver.network.repositories.OrganizationRepository;
 import py.org.fundacionparaguaya.pspserver.security.dtos.UserDetailsDTO;
+import py.org.fundacionparaguaya.pspserver.security.entities.UserEntity;
 import py.org.fundacionparaguaya.pspserver.security.repositories.UserRepository;
 import py.org.fundacionparaguaya.pspserver.surveys.dtos.NewSnapshot;
 import py.org.fundacionparaguaya.pspserver.surveys.entities.SnapshotEconomicEntity;
@@ -103,21 +104,17 @@ public class FamilyServiceImpl implements FamilyService {
 
     @Override
     public FamilyDTO updateFamily(Long familyId, FamilyDTO familyDTO) {
-
-        checkArgument(familyId > 0,
-                i18n.translate("argument.nonNegative", familyId)
-                );
+        checkArgument(familyId > 0, i18n.translate("argument.nonNegative", familyId));
 
         return Optional.ofNullable(familyRepository.findOne(familyId))
                 .map(family -> {
-                    BeanUtils.copyProperties(familyDTO, family);
-                    family.setLastModifiedAt(LocalDateTime.now());
-                    LOG.debug("Changed Information for Family: {}", family);
-                    return family;
+                    // Update family assigned survey user
+                    UserEntity user = userRepo.findById(familyDTO.getUser().getUserId());
+                    family.setUser(user);
+                    return familyRepository.save(family);
                 })
                 .map(familyMapper::entityToDto)
-                .orElseThrow(() -> new UnknownResourceException(i18n
-                        .translate("family.notExist")));
+                .orElseThrow(() -> new UnknownResourceException(i18n.translate("family.notExist")));
     }
 
     @Override

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/impl/FamilyServiceImpl.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/families/services/impl/FamilyServiceImpl.java
@@ -28,8 +28,6 @@ import py.org.fundacionparaguaya.pspserver.security.dtos.UserDetailsDTO;
 import py.org.fundacionparaguaya.pspserver.security.entities.UserEntity;
 import py.org.fundacionparaguaya.pspserver.security.repositories.UserRepository;
 import py.org.fundacionparaguaya.pspserver.surveys.dtos.NewSnapshot;
-import py.org.fundacionparaguaya.pspserver.surveys.entities.SnapshotEconomicEntity;
-import py.org.fundacionparaguaya.pspserver.surveys.repositories.SnapshotEconomicRepository;
 import py.org.fundacionparaguaya.pspserver.system.dtos.ImageDTO;
 import py.org.fundacionparaguaya.pspserver.system.dtos.ImageParser;
 import py.org.fundacionparaguaya.pspserver.system.entities.CityEntity;
@@ -73,8 +71,6 @@ public class FamilyServiceImpl implements FamilyService {
 
     private final ApplicationMapper applicationMapper;
 
-    private final SnapshotEconomicRepository snapshotEconomicRepo;
-
     private final UserRepository userRepo;
 
     private static final String SPACE = " ";
@@ -85,7 +81,6 @@ public class FamilyServiceImpl implements FamilyService {
             CityRepository cityRepository,
             OrganizationRepository organizationRepository,
             ApplicationMapper applicationMapper,
-            SnapshotEconomicRepository snapshotEconomicRepo,
             UserRepository userRepo, I18n i18n, ApplicationProperties applicationProperties,
             ImageUploadService imageUploadService) {
 
@@ -95,7 +90,6 @@ public class FamilyServiceImpl implements FamilyService {
         this.cityRepository = cityRepository;
         this.organizationRepository = organizationRepository;
         this.applicationMapper = applicationMapper;
-        this.snapshotEconomicRepo = snapshotEconomicRepo;
         this.userRepo = userRepo;
         this.i18n = i18n;
         this.applicationProperties=applicationProperties;
@@ -334,16 +328,11 @@ public class FamilyServiceImpl implements FamilyService {
     }
 
     @Override
-    public List<FamilyDTO> listDistinctFamiliesSnapshotByUser(
-            UserDetailsDTO details, String name) {
+    public List<FamilyDTO> listDistinctFamiliesByUser(UserDetailsDTO details, String name) {
 
-        List<SnapshotEconomicEntity> listSnapshots = snapshotEconomicRepo
-                .findDistinctFamilyByUserId(
-                        userRepo.findOneByUsername(details.getUsername()).get()
-                                .getId());
-
-        List<FamilyEntity> families = listSnapshots.stream()
-                .map(s -> new FamilyEntity(s.getFamily()))
+        List<FamilyEntity> families = familyRepository.findDistinctByUserId(
+                userRepo.findOneByUsername(details.getUsername()).get().getId())
+                .stream()
                 .filter(s -> StringUtils.containsIgnoreCase(s.getName(), name)
                         || StringUtils.containsIgnoreCase(s.getCode(), name))
                 .distinct()

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/network/specifications/UserApplicationSpecification.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/network/specifications/UserApplicationSpecification.java
@@ -9,15 +9,19 @@ import py.org.fundacionparaguaya.pspserver.network.entities.OrganizationEntity;
 import py.org.fundacionparaguaya.pspserver.network.entities.OrganizationEntity_;
 import py.org.fundacionparaguaya.pspserver.network.entities.UserApplicationEntity;
 import py.org.fundacionparaguaya.pspserver.network.entities.UserApplicationEntity_;
+import py.org.fundacionparaguaya.pspserver.security.constants.Role;
 import py.org.fundacionparaguaya.pspserver.security.dtos.UserDetailsDTO;
 import py.org.fundacionparaguaya.pspserver.security.entities.UserEntity;
 import py.org.fundacionparaguaya.pspserver.security.entities.UserEntity_;
+import py.org.fundacionparaguaya.pspserver.security.entities.UserRoleEntity;
+import py.org.fundacionparaguaya.pspserver.security.entities.UserRoleEntity_;
 
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Subquery;
 
 public class UserApplicationSpecification {
 
@@ -72,6 +76,21 @@ public class UserApplicationSpecification {
                     builder.like(builder.lower(username), "%" + filter.toLowerCase() + "%"),
                     builder.like(builder.lower(email), "%" + filter.toLowerCase() + "%")
             );
+        };
+    }
+
+    public static Specification<UserApplicationEntity> isSurveyUser() {
+        return (Root<UserApplicationEntity> root, CriteriaQuery<?> query, CriteriaBuilder builder) -> {
+
+            Subquery<Long> surveyUserIds = query.subquery(Long.class);
+            Root<UserRoleEntity> fromUserRole = surveyUserIds.from(UserRoleEntity.class);
+            surveyUserIds
+                    .select(fromUserRole.get(UserRoleEntity_.getUser()).get(UserEntity_.getId()))
+                    .where(builder.equal(fromUserRole.get(UserRoleEntity_.getRole()), Role.ROLE_SURVEY_USER));
+
+            Expression<Long> userId = root.get(UserApplicationEntity_.getUser()).get(UserEntity_.getId());
+
+            return builder.in(userId).value(surveyUserIds);
         };
     }
 

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/entities/UserRoleEntity_.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/entities/UserRoleEntity_.java
@@ -1,0 +1,30 @@
+package py.org.fundacionparaguaya.pspserver.security.entities;
+
+import py.org.fundacionparaguaya.pspserver.security.constants.Role;
+
+import javax.persistence.metamodel.SingularAttribute;
+import javax.persistence.metamodel.StaticMetamodel;
+
+@StaticMetamodel(UserRoleEntity.class)
+public class UserRoleEntity_ {
+
+    private static volatile SingularAttribute<UserRoleEntity, Long> id;
+
+    private static volatile SingularAttribute<UserRoleEntity, UserEntity> user;
+
+    private static volatile SingularAttribute<UserRoleEntity, Role> role;
+
+    private UserRoleEntity_() {}
+
+    public static SingularAttribute<UserRoleEntity, Long> getId() {
+        return id;
+    }
+
+    public static SingularAttribute<UserRoleEntity, UserEntity> getUser() {
+        return user;
+    }
+
+    public static SingularAttribute<UserRoleEntity, Role> getRole() {
+        return role;
+    }
+}

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/repositories/UserRepository.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/repositories/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findUserByEmail(String userEmail);
 
+    UserEntity findById(Long userId);
+
     UserEntity findByUsername(String username);
 
     Page<UserEntity> findAll(Pageable page);

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/UserService.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/UserService.java
@@ -29,4 +29,6 @@ public interface UserService {
     Page<UserDTO> listUsers(UserDetailsDTO userDetails, String filter, PageRequest pageRequest);
 
     List<UserDTO> listUsers(ApplicationDTO application, OrganizationDTO organization);
+
+    List<UserDTO> listSurveyUsers(UserDetailsDTO userDetails);
 }

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/impl/UserServiceImpl.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/impl/UserServiceImpl.java
@@ -42,7 +42,7 @@ import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApp
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.byLoggedUser;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.hasApplication;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.hasOrganization;
-//import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.isSurveyUser;
+import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.isSurveyUser;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.userIsActive;
 
 @Service
@@ -325,7 +325,7 @@ public class UserServiceImpl implements UserService {
                 Specifications
                         .where(byLoggedUser(userDetails))
                         .and(userIsActive())
-//                        .and(isSurveyUser())
+                        .and(isSurveyUser())
         );
 
         return userApplications

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/impl/UserServiceImpl.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/services/impl/UserServiceImpl.java
@@ -42,6 +42,7 @@ import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApp
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.byLoggedUser;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.hasApplication;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.hasOrganization;
+//import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.isSurveyUser;
 import static py.org.fundacionparaguaya.pspserver.network.specifications.UserApplicationSpecification.userIsActive;
 
 @Service
@@ -316,5 +317,20 @@ public class UserServiceImpl implements UserService {
                         .and(userIsActive()));
 
         return userApplications.stream().map(userApplicationMapper::entityToUserDto).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<UserDTO> listSurveyUsers(UserDetailsDTO userDetails) {
+        List<UserApplicationEntity> userApplications = userApplicationRepository.findAll(
+                Specifications
+                        .where(byLoggedUser(userDetails))
+                        .and(userIsActive())
+//                        .and(isSurveyUser())
+        );
+
+        return userApplications
+                .stream()
+                .map(userApplicationMapper::entityToUserDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/web/rest/FamilyController.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/web/rest/FamilyController.java
@@ -124,7 +124,7 @@ public class FamilyController {
             @AuthenticationPrincipal UserDetailsDTO details,
             @RequestParam(value = "name", required = false) String name) {
         return ResponseEntity.ok(familyService
-                .listDistinctFamiliesSnapshotByUser(details, name));
+                .listDistinctFamiliesByUser(details, name));
     }
 
 }

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/web/rest/UserController.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/web/rest/UserController.java
@@ -27,6 +27,7 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequestMapping(value = "/api/v1/users")
@@ -86,6 +87,12 @@ public class UserController {
         PaginableList<UserDTO> response = new PaginableList<>(pageProperties, pageProperties.getContent());
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/survey-users")
+    public ResponseEntity<List<UserDTO>> getSurveyUsers(@AuthenticationPrincipal UserDetailsDTO userDetails) {
+        List<UserDTO> surveyUsers = userService.listSurveyUsers(userDetails);
+        return ResponseEntity.ok(surveyUsers);
     }
 
     @DeleteMapping("/{userId}")


### PR DESCRIPTION
### Checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added necessary documentation (if appropriate)
* [ ] I have added tests that prove my fix is effective or that my feature works (if appropiate)

### Description

FPPSP-263 - El administrador de una organización decide cambiar el asesor de una familia

Una organización puede decidir cambiar el asesor / tomador de encuesta a una familia.
Para poder realizar este procedimiento, debe realizar los siguienes pasos a nivel frontend:
* Seleccionar a la familia sobre la cual desea cambiar el asesor
* Ir al dashboard de la familia
* En la sección "File" o "Ficha" de la familia, agregar la opción de Editar Ficha de la familia
* En esta vista debe tener la opción de cambiar el asesor de la familia, para ello debe dar click y mostrar la lista de usuarios encuestadores que se tiene bajo la organización.
* Seleccionar el usuario encuestador y dar "Aplicar los cambios"
* Preguntar al usuario si está seguro de aplicar los cambios realizados y dar "Aceptar"
* Los cambios realizados se deben reflejar en la ficha de la familia

A nivel de backend se debe actualizar el campo user_id de la tabla family.
La actualización de este campo implica crear los servicios de edición de la familia en caso de no existir y devolver la familia actualizada de tal manera que el cambio se vea reflejado en el frontend.
