### PR TITLE
Fix: ignore user hash password mapping when listing entities with UserEntity members

### DIFF
--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/dtos/UserDTO.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/dtos/UserDTO.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 import javax.validation.constraints.NotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.MoreObjects;
 
 import py.org.fundacionparaguaya.pspserver.network.dtos.ApplicationDTO;
@@ -22,6 +23,7 @@ public class UserDTO implements Serializable{
     private String email;
 
     @NotNull
+    @JsonIgnore
     private String pass;
 
     private boolean active;

--- a/src/main/java/py/org/fundacionparaguaya/pspserver/security/dtos/UserDTO.java
+++ b/src/main/java/py/org/fundacionparaguaya/pspserver/security/dtos/UserDTO.java
@@ -1,14 +1,14 @@
 package py.org.fundacionparaguaya.pspserver.security.dtos;
 
-import java.io.Serializable;
-
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
 import py.org.fundacionparaguaya.pspserver.network.dtos.ApplicationDTO;
 import py.org.fundacionparaguaya.pspserver.network.dtos.OrganizationDTO;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
 
 public class UserDTO implements Serializable{
 
@@ -23,7 +23,6 @@ public class UserDTO implements Serializable{
     private String email;
 
     @NotNull
-    @JsonIgnore
     private String pass;
 
     private boolean active;
@@ -123,6 +122,7 @@ public class UserDTO implements Serializable{
         return role;
     }
 
+    @JsonIgnore
     public String getPass() {
         return pass;
     }
@@ -151,6 +151,7 @@ public class UserDTO implements Serializable{
         this.email = email;
     }
 
+    @JsonProperty
     public void setPass(String pass) {
         this.pass = pass;
     }


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

Put an `x` in the boxes that apply and remove the spaces surrounding the `x` to make the markdown formatting happy ☺️.

* [x] Lint and unit tests pass locally with my changes
* [ ] I have added necessary documentation (if appropriate)
* [ ] I have added tests that prove my fix is effective or that my feature works (if appropiate)

### Description

Fix: ignore user hash password mapping when listing entities with UserEntity members
