### PR TITLE
Added not null rule to Snapshots Economics

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-evolution.xml
+++ b/src/main/resources/db/changelog/db.changelog-evolution.xml
@@ -379,4 +379,9 @@
         <sqlFile path="sql/2018-07-09T10:30.sql" relativeToChangelogFile="true" />
     </changeSet>
 
+    <!-- Added NOT NULL user_id for Snapshot Economics -->
+    <changeSet id="2018-07-24T11:00" author="gcarballude">
+        <sqlFile path="sql/2018-07-24T11:00.sql" relativeToChangelogFile="true"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/sql/2018-07-24T11:00.sql
+++ b/src/main/resources/db/changelog/sql/2018-07-24T11:00.sql
@@ -1,0 +1,4 @@
+-- Existing NULL values for user_id were purged on Testing and 
+-- Demo (Production had none) 
+ALTER TABLE data_collect.snapshots_economics
+   ALTER COLUMN user_id SET NOT NULL;


### PR DESCRIPTION
- Existing null values were purged from Demo Database so the Not Null constraint can be set
- Production Database had no Null user_id entry so the constraint can be set